### PR TITLE
move explanation to later, into numbered remark

### DIFF
--- a/From_a_univ_with_paths.tex
+++ b/From_a_univ_with_paths.tex
@@ -1208,21 +1208,6 @@ as $Jp$ but with the square (\ref{2010.sq1}) replaced by the square
 \subsection{J-structures on universes in categories with two classes of morphisms}
 %
 %
-This is the only part of the paper where we depart from constructions that are
-conservatively algebraic over the theory of categories, i.e., from
-constructions that can be expressed in terms of adding new quasi-algebraic
-operations to the theory of categories without adding new sorts to this theory.
-
-Considering classes of morphisms in categories can be expressed in the
-quasi-algebraic way, but this requires adding new sorts to the theory.
-
-This is also the only context where we use the concept ``there exists'' in this
-paper. In all the previous cases the objects that we considered were given
-(specified). To make the lemmas proved below into constructions and to avoid
-the use of ``there exists'' one would have to define the collection $FB$ as a
-collection of pairs of a morphism $p$ together with, for all $i\in TC$, $f_W$
-and $f_Z$ such that $f_Z\circ p=i\circ f_W$, a morphism $g$ such that $i\circ
-g=f_Z$ and $g\circ p=f_W$.
 
 Recall that a collection of morphisms $R$ is said to have the right lifting
 property for the collection of morphisms $L$ if for any commutative square of
@@ -1246,6 +1231,26 @@ morphisms $FB$ and $TC$ in a category with fiber products and then show in
 Theorems \ref{2015.05.22.th1} and \ref{2015.05.16.th1} how pairs satisfying
 conditions of each of these two sets can be used to construct J-structures on
 elements of $FB$.
+
+\begin{remark}\rm
+  This is the only part of the paper where we depart from constructions that are
+conservatively algebraic over the theory of categories, i.e., from
+constructions that can be expressed in terms of adding new quasi-algebraic
+operations to the theory of categories without adding new sorts to this theory.
+
+Considering classes of morphisms in categories can be expressed in the
+quasi-algebraic way, but this requires adding new sorts to the theory.
+
+This is also the only context where we use the concept ``there exists'' in this
+paper. In all the previous cases the objects that we considered were given
+(specified). To make the lemmas proved below into constructions and to avoid
+the use of ``there exists'' one would have to define the collection $FB$ as a
+collection of pairs of a morphism $p$ together with, for all $i\in TC$, $f_W$
+and $f_Z$ such that $f_Z\circ p=i\circ f_W$, a morphism $g$ such that $i\circ
+g=f_Z$ and $g\circ p=f_W$.
+
+\end{remark}
+
 
 Our first set of conditions is as follows:
 %
@@ -3878,4 +3883,5 @@ $(F',\wt{H}')=\wt{u}_{2,H(\Gamma)}'(H(s0))$.
 
 %% Local Variables:
 %% compile-command: "make From_a_univ_with_paths.pdf "
+%% TeX-master: t
 %% End:


### PR DESCRIPTION
fixes https://github.com/DanGrayson/VV-paths-Csystems-univ-issues/issues/12

- move explanation to later
- diagram now comes first, and explains f_Z and f_W
