### PR TITLE
typo i -> \I

### DIFF
--- a/From_a_univ_with_paths.tex
+++ b/From_a_univ_with_paths.tex
@@ -1574,7 +1574,7 @@ respect to morphisms with fibrant domains through repeated application of
 Lemmas \ref{2015.05.14.l2} and \ref{2015.05.14.l4}. Therefore, the morphism
 $\prI_{pE\wt{\U}}$ is in $FB$ by Lemma \ref{2015.05.14.l1} and as a corollary we
 know that $\I_{pE\wt{\U}}(\U)$ is fibrant. Similarly $\I_p(\U)$ is fibrant and
-$i_p(p)$ is in $FB$ and applying again Lemma \ref{2015.05.14.l2} we see that
+$\I_p(p)$ is in $FB$ and applying again Lemma \ref{2015.05.14.l2} we see that
 $\pr_1$ is in $FB$. And again by Lemma \ref{2015.05.14.l4} we see that $\pFp$ is
 in $FB$ which finishes the proof of the theorem.
 \end{myproof}


### PR DESCRIPTION
fixes https://github.com/DanGrayson/VV-paths-Csystems-univ-issues/issues/16
However, the referee did not identify this as a typo, so maybe my fix is not correct? @DanGrayson : please double-check.